### PR TITLE
Add support for IMG-formatted gff files through the --source flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
 # gff_parser
-Python parser to add external gene calls and functional annotation from Prokka to Anvi'o.
+Python parser to add external gene calls and functional annotation from Prokka
+or IMG to Anvi'o.
 Uses Python3 and gffutils package (https://github.com/daler/gffutils)
 
-Annotate your genome/metagenome with Prokka.
-Use the script to get two files needed for exteranl gene calls and annotations for Anvi'o 
+Annotate your genome/metagenome with Prokka or download annotations from the IMG
+database.
+Use the script to get two files needed for external gene calls and annotations for Anvi'o 
 
-gff_parser.py GFF3_file --gene_calls gene_calls.txt --annotation gene_annot.txt
+```
+gff_parser.py GFF3_file --gene-calls gene_calls.txt --annotation gene_annot.txt
+--source Prokka
+```
 
 This might or might not work for your files. But I hope it works for you too.

--- a/gff_parser.py
+++ b/gff_parser.py
@@ -21,7 +21,7 @@ parser.add_argument('--process-all', default=False, action="store_true", help="P
                     other genetic structures that are not nessecarily translatable, and can cause downstream issues especially if you would like to\
                     use your annotations in contigs databases for pangenomic analyses. As a precation this script only recovers open reading frames\
                     identifie dby Prodigal. Using this flag, you can import everything.")
-parser.add_argument('--source', default='PROKKA', help='Source of gene calls (PROKKA or IMG) (Default: PROKKA)')
+parser.add_argument('--source', default='Prokka', help='Source of gene calls (Prokka or IMG) (Default: Prokka)')
 
 args = parser.parse_args()
 
@@ -32,7 +32,7 @@ OUT_ANNO = open(args.annotation, 'w')
 
 #Check gene caller
 SOURCE = args.source
-if SOURCE == 'PROKKA':
+if SOURCE == 'Prokka':
     SEP = ':'
 elif SOURCE == 'IMG':
     SEP = ' '
@@ -117,7 +117,7 @@ for feature in db.all_features():
             direction='r'
 
     OUT_CDS.write('%d\t%s\t%d\t%d\t%s\t%s\t%d\t%s\t%s\n' % (gene_id, feature.seqid, start, stop, direction, partial, call_type, source, version))
-    OUT_ANNO.write('%d\t%s:%s\t%s\t%s\t%s\n' % (gene_id, 'Prokka', source, gene_acc, product, e_value))
+    OUT_ANNO.write('%d\t%s:%s\t%s\t%s\t%s\n' % (gene_id, SOURCE, source, gene_acc, product, e_value))
 
     gene_id = gene_id + 1
 

--- a/gff_parser.py
+++ b/gff_parser.py
@@ -7,6 +7,7 @@
 
 import gffutils
 import argparse
+import sys
 
 from collections import Counter
 
@@ -20,6 +21,7 @@ parser.add_argument('--process-all', default=False, action="store_true", help="P
                     other genetic structures that are not nessecarily translatable, and can cause downstream issues especially if you would like to\
                     use your annotations in contigs databases for pangenomic analyses. As a precation this script only recovers open reading frames\
                     identifie dby Prodigal. Using this flag, you can import everything.")
+parser.add_argument('--source', default='PROKKA', help='Source of gene calls (PROKKA or IMG) (Default: PROKKA)')
 
 args = parser.parse_args()
 
@@ -27,6 +29,16 @@ args = parser.parse_args()
 GFF = args.gff_file
 OUT_CDS = open(args.gene_calls, 'w')
 OUT_ANNO = open(args.annotation, 'w')
+
+#Check gene caller
+SOURCE = args.source
+if SOURCE == 'PROKKA':
+    SEP = ':'
+elif SOURCE == 'IMG':
+    SEP = ' '
+else:
+    print(SOURCE, "is not an available gene caller.")
+    sys.exit()
 
 #load in the GFF3 file
 db = gffutils.create_db(GFF, ':memory:')
@@ -49,7 +61,7 @@ features_missing_product_or_note = 0
 for feature in db.all_features():
     total_num_features += 1
     # determine source
-    source, version = feature.source.split(':')
+    source, version = feature.source.split(SEP, 1)
 
     # move on if not Prodigal, unless the user wants it badly
     if not args.process_all:


### PR DESCRIPTION
Added a `--source` flag that takes either `IMG` or `Prokka` as input (default: `Prokka`). Anything else kills the program with a warning message. This changes the separator when parsing the `source, version` column of the `.gff` file.